### PR TITLE
use map instead of list to allow overriding returned value when using same argument

### DIFF
--- a/jasmine-spy-when.js
+++ b/jasmine-spy-when.js
@@ -2,18 +2,17 @@
   "use strict";
 
   var newCallFake = function(myArgument) {
-    var argumentListIndex = this.argumentsList.indexOf(myArgument);
+    var hasMockedValue = this.argumentsMap.has(myArgument);
 
-    if(argumentListIndex === -1) {
+    if(!hasMockedValue) {
       return this.defaultValue;
     }
 
-    return this.argumentsListValue[argumentListIndex];
+    return this.argumentsMap.get(myArgument);
   };
 
   jasmine.SpyStrategy.prototype.whenCalled = function() {
-    this.argumentsList = this.argumentsList || [];
-    this.argumentsListValue = this.argumentsListValue || [];
+    this.argumentsMap = this.argumentsMap || new Map();
     this.defaultValue = this.defaultValue || null;
 
     var _this = this;
@@ -32,15 +31,13 @@
   };
 
   jasmine.SpyStrategy.prototype.whenCalledWith = function(argumentValue) {
-    this.argumentsList = this.argumentsList || [];
-    this.argumentsListValue = this.argumentsListValue || [];
+    this.argumentsMap = this.argumentsMap || new Map();
 
-    var _this = this,
-        argumentIndex = this.argumentsList.push(argumentValue) - 1;
+    var _this = this;
 
     return {
       returnValue: function(value) {
-        _this.argumentsListValue[argumentIndex] = value;
+        _this.argumentsMap.set(argumentValue, value)
 
         _this.callFake(function () {
           return newCallFake.apply(_this, arguments);


### PR DESCRIPTION
```js
const spy = jasmine.createSpy('a spy');

// CURRENT BEHAVIOUR
spy.and.whenCalledWith('test').returnValue(1);
console.log(spy()); // 1
spy.and.whenCalledWith('test').returnValue(55);
console.log(spy()); // 1

// BEHAVIOUR WITH THIS PR
spy.and.whenCalledWith('test').returnValue(1);
console.log(spy()); // 1
spy.and.whenCalledWith('test').returnValue(55);
console.log(spy()); // 55
```